### PR TITLE
Adds delay to bots.rb

### DIFF
--- a/bots.rb
+++ b/bots.rb
@@ -22,7 +22,7 @@ class CloneBot < Ebooks::Bot
     self.consumer_key = ""
     self.consumer_secret = ""
     self.blacklist = ['kylelehk', 'friedrichsays', 'Sudieofna', 'tnietzschequote', 'NerdsOnPeriod', 'FSR', 'BafflingQuotes', 'Obey_Nxme']
-
+    self.delay_range = 1..6
     @userinfo = {}
   end
 


### PR DESCRIPTION
Without the delay, the user is prompted with a very unclear "#<TypeError: can't convert NilClass into time interval>" error.
