### PR TITLE
Handle followers who have protected their twitter account

### DIFF
--- a/bots.rb
+++ b/bots.rb
@@ -36,6 +36,13 @@ class CloneBot < Ebooks::Bot
       # Each day at midnight, post a single tweet
       tweet(model.make_statement)
     end
+    
+    scheduler.cron '42 * * * *' do
+      # Every hour, check for protected followers
+      followback
+    end
+
+    followback
   end
 
   def on_message(dm)
@@ -114,6 +121,15 @@ class CloneBot < Ebooks::Bot
       follow(user.screen_name)
     else
       log "Not following @#{user.screen_name}"
+    end
+  end
+
+  def followback
+    twitter.followers.each do |follower|
+      if follower.protected? && !twitter.friendship?(username, follower) && !follower.follow_request_sent?
+        log "Checking if I should followback #{follower.screen_name}"
+        on_follow follower
+      end
     end
   end
 

--- a/bots.rb
+++ b/bots.rb
@@ -110,7 +110,7 @@ class CloneBot < Ebooks::Bot
   end
 
   def on_follow(user)
-    if can_follow?(user.screen_name)
+    if follower.protected? || can_follow?(user.screen_name)
       follow(user.screen_name)
     else
       log "Not following @#{user.screen_name}"


### PR DESCRIPTION
It seems the twitter API doesn't send an event when a protected user follows you.  This means that the bot never follows those users back, never sees their @mentions, and never responds to them.  This PR fixes this by always following back protected accounts and periodically scanning the follower list to see if there are new protected followers to follow back.