### PR TITLE
change Gemfile.lock so it calls for most recent version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,15 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.6)
-    awesome_print (1.2.0)
+    addressable (2.3.8)
+    awesome_print (1.6.1)
     bloomfilter-rb (2.1.1)
       redis
     buftok (0.2.0)
     coderay (1.1.0)
     engtagger (0.2.0)
-    equalizer (0.0.9)
-    eventmachine (1.0.3)
-    faraday (0.9.0)
+    equalizer (0.0.11)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fast-stemmer (1.0.2)
     gingerice (1.2.2)
@@ -19,27 +18,27 @@ GEM
     highscore (1.2.0)
       bloomfilter-rb (>= 2.1.1)
       whatlanguage (>= 1.0.0)
-    htmlentities (4.3.2)
-    http (0.6.3)
+    htmlentities (4.3.4)
+    http (0.6.4)
       http_parser.rb (~> 0.6.0)
     http_parser.rb (0.6.0)
-    json (1.8.1)
+    json (1.8.3)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
     multipart-post (2.0.0)
-    naught (1.0.0)
-    pry (0.10.1)
+    naught (1.1.0)
+    oauth (0.4.7)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    redis (3.1.0)
-    rufus-scheduler (3.0.9)
-      tzinfo
-    simple_oauth (0.3.0)
+    redis (3.2.2)
+    rufus-scheduler (3.1.10)
+    simple_oauth (0.3.1)
     slop (3.6.0)
-    thread_safe (0.3.4)
-    twitter (5.13.0)
+    thread_safe (0.3.5)
+    twitter (5.14.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
       equalizer (~> 0.0.9)
@@ -50,19 +49,16 @@ GEM
       memoizable (~> 0.4.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    twitter_ebooks (3.0.0)
+    twitter_ebooks (3.1.2)
       engtagger
-      eventmachine (~> 1.0.3)
       fast-stemmer
       gingerice
       highscore
       htmlentities
+      oauth
       pry
       rufus-scheduler
-      simple_oauth
-      twitter (~> 5.0)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+      twitter (= 5.14)
     whatlanguage (1.0.5)
 
 PLATFORMS


### PR DESCRIPTION
Solves an issue with bundler calling for twitter_ebooks 3.0 which can cause confusion for novice users.