### PR TITLE
Make can_follow check case-insensitive

### DIFF
--- a/bots.rb
+++ b/bots.rb
@@ -97,7 +97,7 @@ class CloneBot < Ebooks::Bot
   # Only follow our original user or people who are following our original user
   # @param user [Twitter::User]
   def can_follow?(username)
-    @original.nil? || username == @original || twitter.friendship?(username, @original)
+    @original.nil? || username.casecmp(@original) == 0 || twitter.friendship?(username, @original)
   end
 
   def favorite(tweet)


### PR DESCRIPTION
This avoids a bug where if the original user has a cased username on
Twitter, and this bot is configured to use the all-lowercase version,
the bot could unfollow its own creator after attempting to favorite
one of their tweets.